### PR TITLE
update fish config

### DIFF
--- a/fish/config.fish
+++ b/fish/config.fish
@@ -32,6 +32,14 @@ if status is-interactive
     alias rm="rm -ir"
     alias cp="cp -r"
     alias mv="mv -i"
+    alias dir='dir --color=auto'
+    alias egrep='egrep --color=auto'
+    alias fgrep='fgrep --color=auto'
+    alias grep='grep --color=auto'
+    alias grubup="sudo update-grub"
+    alias upd='/usr/bin/update'
+    alias vdir='vdir --color=auto'
+    alias wget='wget -c '
 end
 
 


### PR DESCRIPTION
# New Patch; 
In this patch just adding a couple of aliases to the fish config file so that it is easy to work.

## Config File Alias:
These are the alias that have been added to the config File:
    alias ls="lsd"
    alias rm="rm -ir"
    alias cp="cp -r"
    alias mv="mv -i"
    alias dir='dir --color=auto'
    alias egrep='egrep --color=auto'
    alias fgrep='fgrep --color=auto'
    alias grep='grep --color=auto'
    alias grubup="sudo update-grub"
    alias upd='/usr/bin/update'
    alias vdir='vdir --color=auto'
    alias wget='wget -c '